### PR TITLE
(fix) Crash null wrapper in SignEditScreenMixin.

### DIFF
--- a/src/main/java/jp/axer/cocoainput/mixin/SignEditScreenMixin.java
+++ b/src/main/java/jp/axer/cocoainput/mixin/SignEditScreenMixin.java
@@ -14,7 +14,7 @@ import net.minecraft.client.gui.screens.inventory.SignEditScreen;
 public class SignEditScreenMixin {
 	 SignEditScreenWrapper wrapper;
 	 
-	 @Inject(method="init",at=@At("RETURN"))
+	 @Inject(method="init*",at=@At("RETURN"))
 	 private void init(CallbackInfo ci) {
 		 wrapper = new SignEditScreenWrapper((SignEditScreen)(Object)this);
 	 }


### PR DESCRIPTION
#2 の修正の試み
私の環境では不具合は再現しなかったが、wrapperが初期化されないケースが想定されます。
派生元のScreenにはinit()が２つあるため、BookEditScreenMixinと同様のInjectの書式に修正しました。
