### PR TITLE
Fix/crash null wrapper in sign edit screen mixin

### DIFF
--- a/src/main/java/jp/axer/cocoainput/mixin/SignEditScreenMixin.java
+++ b/src/main/java/jp/axer/cocoainput/mixin/SignEditScreenMixin.java
@@ -21,6 +21,7 @@ public class SignEditScreenMixin {
 	 
 	 @Redirect(method="tick",at = @At(value="FIELD", target="Lnet/minecraft/client/gui/screens/inventory/SignEditScreen;frame:I",opcode=Opcodes.PUTFIELD))
 	 private void injectCurosr(SignEditScreen esc,int n) {
+		 if (wrapper == null) wrapper = new SignEditScreenWrapper((SignEditScreen)(Object)this);	// May come before init() is called by stendhal-1.3.3-1.19.jar
 		 esc.frame=wrapper.renewCursorCounter();
 	 }
 }


### PR DESCRIPTION
Fixed a problem that stendhal-1.3.3-1.19.jar crashes without calling init().

[CocoaInput-1.19-fabric-4.0.5-PREVIEW.jar.zip](https://github.com/nakanotti/CocoaInput/files/9068850/CocoaInput-1.19-fabric-4.0.5-PREVIEW.jar.zip)

