### PR TITLE
Fix X11 Input

### DIFF
--- a/libcocoainput/x11/libx11cocoainput.c
+++ b/libcocoainput/x11/libx11cocoainput.c
@@ -197,7 +197,7 @@ void initialize(
                 XNFocusWindow,
                 xwindow,
                 XNInputStyle,
-                XIMPreeditCallbacks|XIMStatusNone,
+                XIMPreeditCallbacks|XIMStatusCallbacks,
                 //XIMPreeditNothing|XIMStatusNothing,
                 XNPreeditAttributes,
                 preeditCallbacksList(),


### PR DESCRIPTION
Fix the https://github.com/nakanotti/CocoaInput/issues/16#issuecomment-1537777136

OS: Ubuntu 22.04
Arch: x86_64
IME: fcitx-rime X11
Minecraft 1.19.2 & 1.19.4

Result:

https://user-images.githubusercontent.com/41978811/236996127-d234db07-58e6-439c-8879-f68e493e3f34.mp4

